### PR TITLE
Multiple rooms

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,12 @@ connectors:
     # Required
     mxid: "@username:matrix.org"
     password: "mypassword"
+    # Name of a single room to connect to
     room: "#matrix:matrix.org"
+    # Alternatively, a dictionary of multiple rooms
+    # One of these should be named 'main'
+    rooms: {'main': '#matrix:matrix.org',
+            'other': '#riot:matrix.org'}
     # Optional
     homeserver: "https://matrix.org"
     nick: "Botty McBotface"  # The nick will be set on startup

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ connectors:
     room: "#matrix:matrix.org"
     # Alternatively, a dictionary of multiple rooms
     # One of these should be named 'main'
-    rooms: {'main': '#matrix:matrix.org',
-            'other': '#riot:matrix.org'}
+    rooms:
+      'main': '#matrix:matrix.org'
+      'other': '#riot:matrix.org'
     # Optional
     homeserver: "https://matrix.org"
     nick: "Botty McBotface"  # The nick will be set on startup

--- a/connector.py
+++ b/connector.py
@@ -123,7 +123,8 @@ class ConnectorMatrix(Connector):
 
     async def respond(self, message):
         # Send message.text back to the chat service
-        await self.connection.send_message(self.room_id, message.text)
+        # Connector responds in the same room it received the original message
+        await self.connection.send_message(message.room, message.text)
 
     async def disconnect(self):
         self.session.close()

--- a/connector.py
+++ b/connector.py
@@ -17,7 +17,9 @@ class ConnectorMatrix(Connector):
         # Init the config for the connector
         self.name = "ConnectorMatrix"  # The name of your connector
         self.config = config  # The config dictionary to be accessed later
-        self.rooms = config['rooms']
+        self.rooms = config.get('rooms', None)
+        if not self.rooms:
+            self.rooms = {'main': config['room']}
         self.room_ids = {}
         self.default_room = self.rooms['main']
         self.mxid = config['mxid']

--- a/connector.py
+++ b/connector.py
@@ -107,16 +107,17 @@ class ConnectorMatrix(Connector):
                     filter=self.filter_id)
                 _LOGGER.debug("matrix sync request returned")
                 self.connection.sync_token = response["next_batch"]
-                room = response['rooms']['join'].get(self.room_id, None)
-                if room and 'timeline' in room:
-                    for event in room['timeline']['events']:
-                        if event['content']['msgtype'] == 'm.text':
-                            if event['sender'] != self.mxid:
-                                message = Message(event['content']['body'],
-                                                  await self.connection.get_room_displayname(self.default_room,
-                                                                                             event['sender']),
-                                                  None, self)
-                                await opsdroid.parse(message)
+                for roomid in self.room_ids.values():
+                    room = response['rooms']['join'].get(roomid, None)
+                    if room and 'timeline' in room:
+                        for event in room['timeline']['events']:
+                            if event['content']['msgtype'] == 'm.text':
+                                if event['sender'] != self.mxid:
+                                    message = Message(event['content']['body'],
+                                                    await self.connection.get_room_displayname(self.default_room,
+                                                                                                event['sender']),
+                                                    roomid, self)
+                                    await opsdroid.parse(message)
             except Exception as e:
                 _LOGGER.exception('Matrix Sync Error')
 

--- a/connector.py
+++ b/connector.py
@@ -17,7 +17,8 @@ class ConnectorMatrix(Connector):
         # Init the config for the connector
         self.name = "ConnectorMatrix"  # The name of your connector
         self.config = config  # The config dictionary to be accessed later
-        self.default_room = config['room']
+        self.rooms = config['rooms']
+        self.default_room = self.rooms['main']
         self.mxid = config['mxid']
         self.nick = config.get('nick', None)
         self.homeserver = config.get('homeserver', "https://matrix.org")
@@ -77,8 +78,9 @@ class ConnectorMatrix(Connector):
         mapi.token = login_response['access_token']
         mapi.sync_token = None
 
-        response = await mapi.join_room(self.default_room)
         self.room_id = response['room_id']
+        for roomname, room in self.rooms.items():
+            response = await mapi.join_room(room)
         self.connection = mapi
 
         # Create a filter now, saves time on each later sync


### PR DESCRIPTION
Add tentative support for multiple matrix rooms. Listens for messages in all rooms specified in the config and responds to received messages in the same room.

Closes #4 .