### PR TITLE
Remove the sync message limit

### DIFF
--- a/connector.py
+++ b/connector.py
@@ -87,7 +87,6 @@ class ConnectorMatrix(Connector):
                     "types": []
                 },
                 "timeline": {
-                    "limit": 10,
                     "types": ["m.room.message"]
                 },
                 "ephemeral": {


### PR DESCRIPTION
When we use this filter, we should always have a previous token, and if the matrix server goes offline for a short while, we probably want to process all the messages we haven't seen, not just the last 10.